### PR TITLE
Fix for bug 3365134

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -359,8 +359,19 @@ def transform_alerts(string):
 
 def transform_colors(string):
     """ colors """
+    def maybe_replace(m):
+        """ only replace if we are not within <<< >>> """
+        for g in graphics:
+            # found color is within a graphics token
+            if m.start() >= g.start() and m.end() <= g.end():
+                return m.string[m.start():m.end()]
+
+        return "\\textcolor{" + m.group(1) + "}{" + m.group(2) + "}"
+
+    p = re.compile("(\<\<\<)(.*?)\>\>\>", re.VERBOSE)
+    graphics = list(p.finditer(string))
     p = re.compile("_([^_\\\\{}]*?)_([^_]*?[^_\\\\{}])_", re.VERBOSE)
-    string = p.sub(r"\\textcolor{\1}{\2}", string) 
+    string = p.sub(maybe_replace, string)
     return string
    
 def transform_footnotes(string):

--- a/tests/test_wiki2beamer.py
+++ b/tests/test_wiki2beamer.py
@@ -137,6 +137,13 @@ class TestTransform(unittest.TestCase):
         self.assertEqual(transform(r'\frac{V_1}{R_1}=\frac{V_2}{R_2}', self.state),
                 r'\frac{V_1}{R_1}=\frac{V_2}{R_2}')
 
+        # test for bug 3365134
+        # colors interfere with graphics
+        self.assertEqual(transform(r'<<<file/foo_bar/baz_dazz_baz>>>',
+            self.state),'\includegraphics{file/foo_bar/baz_dazz_baz}')
+        self.assertEqual(transform(r'_blue_make me blue_ <<<file/foo_bar_/baz_fasel.svg>>>',
+            self.state),r'\textcolor{blue}{make me blue} \includegraphics{file/foo_bar_/baz_fasel.svg}')
+
 class TestExpandCode(unittest.TestCase):
     def test_search_escape_sequences_basic(self):
         code = "System435.out.println(\"foo\");123System.ou12t.println234(\"foo\");System.23out.23456println(\"foo\");S237yst28em.out.pr18intln(\"foo\");"


### PR DESCRIPTION
Filenames for graphics can have underscores. It doesn't interfere
with colors any longer.
