### PR TITLE
Implicit decode cause UnicodeDecodeError

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -609,7 +609,7 @@ def expand_code_getname(code):
         'a':'k', 'b':'l', 'c':'m', 'd':'n', 'e':'o', 'f':'p' \
     }
     
-    hexhash = md5hex(code.encode('utf8'))
+    hexhash = md5hex(code)
     alphahash = ''.join(list([hex2alpha_table[x] for x in hexhash]))
     return alphahash
 


### PR DESCRIPTION
Python already works with encoded strings. Thus when calling encode an implicit
decode is called and cause UnicodeDecodeError if non-ASCII chars are used. See
http://docs.python.org/2/howto/unicode.html#the-unicode-type
