### PR TITLE
Allow using code in itemenums

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -1047,10 +1047,10 @@ def convert2beamer_full(lines):
                 codebuffer = []
             elif not _codemode and codemode: #code mode was turned off
                 expand_code_segment(result, codebuffer, state)
-            codemode = _codemode
 
-            if codemode:
+            if codemode | _codemode:
                 codebuffer.append(line)
+                codemode = _codemode
             else:
                 (line, _autotemplatemode) = get_autotemplatemode(line, autotemplatemode)
                 if _autotemplatemode and not autotemplatemode: #autotemplate mode was turned on

--- a/tests/test_wiki2beamer.py
+++ b/tests/test_wiki2beamer.py
@@ -378,19 +378,19 @@ class TestFileInclusion(unittest.TestCase):
         self.assertRaises(Exception, include_file_recursive, 'test_file_loop')
 
     def test_include_file_disabled_inside_code(self):
-        expected = ['\\defverbatim[colored]\\mfkjiamnpineejahopjoapckhioohfpa{\n\\begin{lstlisting}>>>test_file<<<\\end{lstlisting}\n}\n', '\n\\mfkjiamnpineejahopjoapckhioohfpa\n', '', '']
+        expected = ['\\defverbatim[colored]\\mfkjiamnpineejahopjoapckhioohfpa{\n\\begin{lstlisting}>>>test_file<<<\\end{lstlisting}\n}\n', '\n\\mfkjiamnpineejahopjoapckhioohfpa\n', '']
         out = include_file_recursive('test_file_code')
         out = convert2beamer(out)
         self.assertEqual(out,expected)
 
     def test_include_file_inside_code_inside_nowiki(self):
-        expected = ['\\defverbatim[colored]\\nebnimnjipaalcaeojiaajjiompiecho{\n\\begin{lstlisting}\\end{lstlisting}\n}\n', '', '>>>test_file<<<', '\n\\nebnimnjipaalcaeojiaajjiompiecho\n', '', '']
+        expected = ['\\defverbatim[colored]\\nebnimnjipaalcaeojiaajjiompiecho{\n\\begin{lstlisting}\\end{lstlisting}\n}\n', '', '>>>test_file<<<', '\n\\nebnimnjipaalcaeojiaajjiompiecho\n', '']
         out = include_file_recursive('test_file_code_nowiki')
         out = convert2beamer(out)
         self.assertEqual(out,expected)
     
     def test_include_file_after_code(self):
-        expected = ['\\defverbatim[colored]\\nebnimnjipaalcaeojiaajjiompiecho{\n\\begin{lstlisting}\\end{lstlisting}\n}\n', '\n\\nebnimnjipaalcaeojiaajjiompiecho\n', '', 'test file content', '']
+        expected = ['\\defverbatim[colored]\\nebnimnjipaalcaeojiaajjiompiecho{\n\\begin{lstlisting}\\end{lstlisting}\n}\n', '\n\\nebnimnjipaalcaeojiaajjiompiecho\n', 'test file content', '']
         out = include_file_recursive('test_file_include_after_code')
         out = convert2beamer(out)
         self.assertEqual(out, expected)


### PR DESCRIPTION
This avoids closing all itemenums after(!) a code section.
