### PR TITLE
 open changelog for 0.10.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ Version 0.10.0 (2012-03-31)
 * Fix Python 3.3 compatibility
 * Support code within items
 * Support markers for items (*[C] text)
+* Add titleframeopts
+* Fix regex issues for python 3.7
 * Many many bugfixes, code cleanups and typo fixes
 
 Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek, Michael Adam, Michael

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Version 0.10.0 (2012-03-31)
 =======================================
+* Fix hash collisions in code include
 * Allow '\' to be used as line continuation
 * Travis-CI support
 * Fix Python 3.3 compatibility
@@ -7,8 +8,8 @@ Version 0.10.0 (2012-03-31)
 * Support markers for items (*[C] text)
 * Many many bugfixes, code cleanups and typo fixes
 
-Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek and Moritz Strübe for their
-work leading to this release.
+Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek, Michael Adam, Michael
+Legrin and Moritz Strübe for their work leading to this release.
 
 Version 0.9.5 (2012-03-31)
 =======================================

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+Version 0.10.0 (2012-03-31)
+=======================================
+* Allow '\' to be used as line continuation
+* Travis-CI support
+* Fix Python 3.3 compatibility
+* Support code within items
+* Support markers for items (*[C] text)
+* Many many bugfixes, code cleanups and typo fixes
+
+Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek and Moritz Strübe for their
+work leading to this release.
+
 Version 0.9.5 (2012-03-31)
 =======================================
 Added -o,--output option

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ Version 0.10.0 (2012-03-31)
 * Fix regex issues for python 3.7
 * Many many bugfixes, code cleanups and typo fixes
 
-Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek, Michael Adam, Michael
+Thanks to Sam Tygier, Zbigniew Jędrzejewski-Szmek, Michael Adam, Gregory
 Legrin and Moritz Strübe for their work leading to this release.
 
 Version 0.9.5 (2012-03-31)


### PR DESCRIPTION
Alternative for #22 

I prefer to have just a single bullet for all the bugfixes etc.. Also, I don't really like the who-did-what style changelog, since that can be extracted from the git history. Usually people want to glance at the change-log and have a high-level overview of important changes. Having said that, I am open to negotiation. :)
