### PR TITLE
Solve issue with character not properly escaped

### DIFF
--- a/code/wiki2beamer
+++ b/code/wiki2beamer
@@ -242,7 +242,7 @@ def get_frame_closing(state):
 
 def transform_spec_to_title_slide(string, state):
 
-    frame_opening = r"\n\\begin{frame}\n\\frametitle{}\n\\begin{center}\n{\Huge \1}\n\\end{center}\n"
+    frame_opening = r"\n\\begin{frame}\n\\frametitle{}\n\\begin{center}\n{\\Huge \1}\n\\end{center}\n"
     frame_closing = escape_resub(get_frame_closing(state))
 
     p = re.compile("^=!\s*(.*?)\s*!=(.*)", re.VERBOSE)


### PR DESCRIPTION
Hi,
it seems that there is a small issue in `master` with a `\Huge` not properly escaped (it fails on my workstation (`Python 3.7.3 (default, Mar 26 2019, 21:43:19)`).

Best regards,
G.