### PR TITLE
Switch to codecov for coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,8 @@ jobs:
       run: |
         pytest tests/
 
-    - name: Upload coverage to Coveralls
+    - name: Upload coverage reports to Codecov
       if: matrix.python-version == '3.12'
-      uses: coverallsapp/github-action@v2
+      uses: codecov/codecov-action@v5
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        file: .coverage
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This PR switches coverage tool from coveralls to codecov

There is a related issue for this:   https://github.com/wiki2beamer/wiki2beamer/issues/48

Here is how it looks on my fork:  https://app.codecov.io/github/vladistan/wiki2beamer/tree/switch-to-codecov/src%2Fwiki2beamer

To make this work we need to:

1.  Install CodeCov app into wiki2beamer organization. ( I just sent you a request for this)
2. Add CODECOV_TOKEN secret to repository or organization
